### PR TITLE
Add 2023 Thai demand data

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ Contributions are welcome in the form of new links to websites that provide hour
 
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Zenodo](https://zenodo.org/records/7537890) | 2017-2022 | 10-min resolution | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
 
+- #### Thailand
+
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Zenodo](https://zenodo.org/records/15219959) | 2023 | 60-min resolution | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+
 - #### Turkey
 
   &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[EPIAS](https://kayit.epias.com.tr/epias-transparency-platform-registration-form) | 2016-present | 60-min resolution | [Access upon request – Use with attribution](https://seffaflik.epias.com.tr/about/about)

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Contributions are welcome in the form of new links to websites that provide hour
 
 - #### Thailand
 
-  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Zenodo](https://zenodo.org/records/15219959) | 2023 | 60-min resolution | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
+  &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;[Zenodo](https://doi.org/10.5281/zenodo.17109911) | 2023-2024 | 60-min resolution | [CC-BY 4.0](https://creativecommons.org/licenses/by/4.0/legalcode)
 
 - #### Turkey
 


### PR DESCRIPTION
I have added an entry to the main GitHub page. The entry links to my working paper on modeling renewable energy contracts in a production cost model.

The demand data was scraped from the utility (https://www.egat.co.th/).